### PR TITLE
Change "/tag" to "/pvptag"

### DIFF
--- a/PvPManager/src/main/resources/plugin.yml
+++ b/PvPManager/src/main/resources/plugin.yml
@@ -36,7 +36,7 @@ commands:
       description: List all players with pvp enabled
       aliases: [plist, pvpl]
       permission: pvpmanager.list
-   tag:
+   pvptag:
       description: Shows time left until out of combat
       aliases: [ct, pt, pvptag]
    announce:


### PR DESCRIPTION
##### Resolves #201
## Changes:
* PvPManager/src/main/java/me/NoChance/PvPManager/PvPManager.java
*  PvPManager/src/main/resources/plugin.yml

## Description:
Changes the "/tag" command to "/pvptag" to correct a conflict with the built-in Minecraft command, "/tag". 